### PR TITLE
update gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
On machines without autocrlf set properly, the .gitattributes file could cause the line endings to get in a weird state. According to https://stackoverflow.com/questions/56857990/whats-the-difference-between-text-auto-eol-lf-and-text-eol-lf-in-gitat/56858538#56858538, fixing the line to text=auto should fix this problem.